### PR TITLE
fix: Reparation et automatisation des unittests

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,6 +13,8 @@ jobs:
     name: Run pytests
     runs-on: ubuntu-latest
     steps:
+      - name: generate FR locale
+        run: sudo locale-gen fr_FR.UTF-8
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,27 @@
+name: Run Pytests
+
+on:
+  # Run workflow automatically whenever the app or tests are updated
+  push:
+    paths:
+      - app/**
+      - tests/**
+
+jobs:
+  pytest:
+    name: Run pytests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r app/requirements.txt
+      - name: Test with pytest
+        run: |
+          pip install pytest pytest-cov
+          python -m pytest ../tests --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -16,7 +16,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Lint with Ruff
+        run: |
+          pip install ruff
+          ruff --output-format=github app/
+        continue-on-error: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -3,9 +3,10 @@ name: Run Pytests
 on:
   # Run workflow automatically whenever the app or tests are updated
   push:
-#    paths:
-#      - app/**
-#      - tests/**
+    paths:
+      - .github/workflows/pytest.yaml
+      - app/**
+      - tests/**
 
 jobs:
   pytest:
@@ -30,4 +31,4 @@ jobs:
       - name: Test with pytest
         run: |
           pip install pytest pytest-cov
-          python -m pytest ../tests --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+          python -m pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -3,9 +3,9 @@ name: Run Pytests
 on:
   # Run workflow automatically whenever the app or tests are updated
   push:
-    paths:
-      - app/**
-      - tests/**
+#    paths:
+#      - app/**
+#      - tests/**
 
 jobs:
   pytest:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,31 +1,11 @@
-# All services required to test myelectricaldata
 version: "3.9"
 services:
-  homeassistant:
-    image: ghcr.io/home-assistant/home-assistant:stable
-    privileged: true
+  myelectricaldata:
+    image: m4dm4rtig4n/myelectricaldata:latest
     restart: unless-stopped
+    volumes:
+      - ./data:/data
     environment:
       TZ: Europe/Paris
-    volumes:
-      - ./tests/integration/homeassistant/config:/config
-      - /run/dbus:/run/dbus:ro
     ports:
-      - 8123:8123
-  mqtt:
-    image: emqx/nanomq:latest
-    ports:
-      - 1893:1883
-      - 8093:8083
-      - 8893:8883
-  myelectricaldata:
-    build: .
-    depends_on:
-      - mqtt
-      - homeassistant
-    ports:
-      - 5000:5000
-    environment:
-      DEBUG: true
-    volumes:
-      - ./tests/integration/myelectricaldata:/data
+      - '5000:5000'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,31 @@
+# All services required to test myelectricaldata
 version: "3.9"
 services:
-  myelectricaldata:
-    image: m4dm4rtig4n/myelectricaldata:latest
+  homeassistant:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    privileged: true
     restart: unless-stopped
-    volumes:
-      - ./data:/data
     environment:
       TZ: Europe/Paris
+    volumes:
+      - ./tests/integration/homeassistant/config:/config
+      - /run/dbus:/run/dbus:ro
     ports:
-      - '5000:5000'
+      - 8123:8123
+  mqtt:
+    image: emqx/nanomq:latest
+    ports:
+      - 1893:1883
+      - 8093:8083
+      - 8893:8883
+  myelectricaldata:
+    build: .
+    depends_on:
+      - mqtt
+      - homeassistant
+    ports:
+      - 5000:5000
+    environment:
+      DEBUG: true
+    volumes:
+      - ./tests/integration/myelectricaldata:/data

--- a/tests/data/.placeholder
+++ b/tests/data/.placeholder
@@ -1,0 +1,1 @@
+-- Unittest data will be placed in this directory


### PR DESCRIPTION
### Motivation
Les tests definis dans la PR https://github.com/MyElectricalData/myelectricaldata_import/pull/449 ne fonctionnaient pas de maniere reproductible

### Changements
- Ajout d'un workflow pour executer les unittests a chaque modification du workflow, du code ou des tests
- Ajout du dossier `tests/data/` afin de resoudre le probleme d'execution des unittests
- Ajout d'une etape de linting afin de detecter les ameliorations et regressions en termes d'ecriture du code

### Testing
Voici un exemple d'execution des tests: https://github.com/koukihai/myelectricaldata_import/actions/runs/7297800030/job/19887640881
 
### Note
La PR https://github.com/MyElectricalData/myelectricaldata_import/pull/449 semble avoir aussi desactive les logs applicatifs. Cette PR ne repare pas ce probleme.

N'hesitez pas a rejeter cette PR ainsi qu'a revert la [PR precedente](https://github.com/MyElectricalData/myelectricaldata_import/pull/449) si vous souhaitez que je repare les logs en meme temps