### PR TITLE
Unittests for jobs.py

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 from math import floor
-from os import environ, getenv
+from os import environ, getenv, path
 
 from art import decor, text2art
 
@@ -130,7 +130,8 @@ def finish():
 
 
 def get_version():
-    f = open("/app/VERSION", "r")
+    version_file = path.join(APPLICATION_PATH, "VERSION")
+    f = open(version_file, "r")
     version = f.read()
     f.close()
     return version.strip()

--- a/app/init.py
+++ b/app/init.py
@@ -15,8 +15,9 @@ from models.mqtt import Mqtt
 
 # LOGGING CONFIGURATION
 config = {}
-if path.exists("/data/config.yaml"):
-    with open(f'/data/config.yaml') as file:
+CONFIG_PATH = path.join(APPLICATION_PATH_DATA, "config.yaml")
+if path.exists(CONFIG_PATH):
+    with open(CONFIG_PATH) as file:
         config = yaml.load(file, Loader=yaml.FullLoader)
 
 if "DEBUG" in environ and str2bool(getenv("DEBUG")):
@@ -43,8 +44,8 @@ else:
         level=logging_level
     )
 
-if not path.exists("/data/config.yaml"):
-    logging.critical("Config file is not found (/data/config.yaml)")
+if not path.exists(CONFIG_PATH):
+    logging.critical(f"Config file is not found ({CONFIG_PATH})")
     exit()
 
 

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -4,12 +4,12 @@ import re
 
 import yaml
 
-from dependencies import title, separator
+from dependencies import title, separator, APPLICATION_PATH_DATA
 
 
 class Config:
 
-    def __init__(self, path="/data"):
+    def __init__(self, path=APPLICATION_PATH_DATA):
         self.path = path
         self.db = None
         self.file = "config.yaml"
@@ -128,14 +128,14 @@ class Config:
     def load(self):
         config_file = f'{self.path_file}'
         if os.path.exists(config_file):
-            with open(f'{self.path}/config.yaml') as file:
+            with open(config_file) as file:
                 self.config = yaml.load(file, Loader=yaml.FullLoader)
 
         else:
             f = open(config_file, "a")
             f.write(yaml.dump(self.default))
             f.close()
-            with open(f'{self.path}/config.yaml') as file:
+            with open(config_file) as file:
                 self.config = yaml.load(file, Loader=yaml.FullLoader)
 
         if self.config is None:

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -9,7 +9,6 @@ from os.path import exists
 from sqlalchemy import (create_engine, delete, inspect, update, select, func, desc, asc)
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
-
 from config import MAX_IMPORT_TRY
 from db_schema import (
     Config,
@@ -26,14 +25,14 @@ from db_schema import (
     Ecowatt,
     Statistique
 )
-from dependencies import str2bool, title, get_version, title_warning
+from dependencies import str2bool, title, get_version, title_warning, APPLICATION_PATH_DATA, APPLICATION_PATH
 
 # available_database = ["sqlite", "postgresql", "mysql+pymysql"]
 available_database = ["sqlite", "postgresql"]
 
 
 class Database:
-    def __init__(self, config, path="/data"):
+    def __init__(self, config, path=APPLICATION_PATH_DATA):
         self.config = config
         self.path = path
 
@@ -48,7 +47,7 @@ class Database:
             else:
                 logging.critical(f"Database {self.storage_type} not supported (only SQLite & PostgresSQL)")
 
-        os.system(f"cd /app; DB_URL='{self.uri}' alembic upgrade head ")
+        os.system(f"cd {APPLICATION_PATH}; DB_URL='{self.uri}' alembic upgrade head ")
 
         self.engine = create_engine(
             self.uri, echo=False,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = app
+log_level = DEBUG

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,0 +1,57 @@
+# Tests Unitaires
+
+### Execution manuelle
+Pour executer les tests unitaires de ce projet, veuillez vous placer a la racine du projet, et executez la commande
+suivante:
+
+```commandline
+pip install pytest pytest-cov pytest-mock
+python -m pytest --cov=app/ --cov-report=xml
+```
+
+### Execution automatisée
+Pour executer les tests unitaires a partir d'une github action, veuillez utiliser une action similaire a la suivante:
+
+```file
+name: Run Pytests
+
+on:
+  # Run workflow automatically whenever the workflow, app or tests are updated
+  push:
+    paths:
+      - .github/workflows/pytest.yaml                    # Assuming this file is stored in .github/workflows/pytest.yaml
+      - app/**
+      - tests/**
+
+jobs:
+  pytest:
+    name: Run pytests
+    runs-on: ubuntu-latest
+    steps:
+      - name: generate FR locale
+        run: sudo locale-gen fr_FR.UTF-8
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Lint with Ruff                             # Running an optional linter step
+        run: |
+          pip install ruff
+          ruff --output-format=github app/
+        continue-on-error: true
+      - name: Install application dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r app/requirements.txt
+      - name: Test with pytest
+        run: |
+          pip install pytest pytest-cov pytest-mock
+          pytest --cov=app/ --cov-report=xml
+      - name: Upload coverage reports to Codecov         # Optional: Run codecov. Requires: secrets.CODECOV_TOKEN
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: true
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,74 @@
+import os
+import tempfile
+from contextlib import contextmanager
+
+import yaml
+import pytest
+import logging
+
+
+@contextmanager
+def setenv(**envvars):
+    old_env = os.environ.copy()
+    try:
+        for envvar, value in envvars.items():
+            os.environ[envvar] = value
+        yield
+    finally:
+        os.environ = old_env
+
+
+@contextmanager
+def mock_config(data_dir):
+    filename = "config.yaml"
+    config = {
+        "home_assistant": {"enable": "False"},
+        "myelectricaldata": {
+            "pdl1": {
+                "enable": True,
+                "consumption": True,
+                "consumption_detail": True,
+                "production": True,
+                "production_detail": True
+            },
+            "pdl2": {"enable": False},
+            "pdl3": {"enable": False}
+        }
+    }
+
+    with open(os.path.join(data_dir, filename), "w") as fp:
+        yaml.dump(config, fp)
+    print(f"created {fp.name} for testing")
+    yield
+
+
+@contextmanager
+def mock_datadir():
+    with tempfile.TemporaryDirectory() as data_dir:
+        yield data_dir
+
+
+# TODO: Extract as a function in main.py to avoid duplication
+def copied_from_main():
+    from init import CONFIG, DB
+    usage_point_list = []
+    if CONFIG.list_usage_point() is not None:
+        for upi, upi_data in CONFIG.list_usage_point().items():
+            logging.info(f"{upi}")
+            DB.set_usage_point(upi, upi_data)
+            usage_point_list.append(upi)
+            logging.info("  => Success")
+    else:
+        logging.warning("Aucun point de livraison détecté.")
+
+    DB.clean_database(usage_point_list)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def update_paths():
+    project_root = os.path.abspath(os.path.join(os.path.realpath(__file__), "..", ".."))
+    app_path = os.path.join(project_root, "app")
+    with mock_datadir() as data_dir:
+        with setenv(APPLICATION_PATH=app_path, APPLICATION_PATH_DATA=data_dir), mock_config(data_dir):
+            copied_from_main()
+            yield

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,208 @@
+import pytest
+
+from db_schema import UsagePoints
+from tests.conftest import setenv
+
+EXPORT_METHODS = ["export_influxdb", "export_home_assistant_ws", "export_home_assistant", "export_mqtt"]
+PER_USAGE_POINT_METHODS = ["get_account_status", "get_contract", "get_addresses", "get_consumption",
+                           "get_consumption_detail", "get_production", "get_production_detail",
+                           "get_consumption_max_power", "stat_price"] + EXPORT_METHODS
+PER_JOB_METHODS = ["get_gateway_status", "get_tempo", "get_ecowatt"]
+
+
+@pytest.fixture(params=[None, 'pdl1'])
+def job(request):
+    from models.jobs import Job
+
+    print(f"Using job with usage point id = {request.param}")
+    job = Job(request.param)
+    job.wait_job_start = 1
+    yield job
+
+
+@pytest.mark.parametrize("envvar_to_true", [None, "DEV", "DEBUG"])
+def test_boot(mocker, caplog, job, envvar_to_true):
+    m = mocker.patch('models.jobs.Job.job_import_data')
+
+    if envvar_to_true:
+        with setenv(**{envvar_to_true: "true"}):
+            res = job.boot()
+    else:
+        res = job.boot()
+
+    assert res is None
+    if envvar_to_true in ["DEV"]:
+        assert 0 == m.call_count, "job_import_data should not be called"
+        assert 'WARNING  root:jobs.py:43 => Import job disable\n' == caplog.text
+    else:
+        # FIXME: job_import_data is called when DEBUG=true
+        assert "" == caplog.text
+        m.assert_called_once()
+
+
+def test_job_import_data(mocker, job, caplog):
+    mockers = {}
+    for method in PER_JOB_METHODS + PER_USAGE_POINT_METHODS:
+        mockers[method] = mocker.patch(f"models.jobs.Job.{method}")
+
+    count_enabled_jobs = len([j for j in job.usage_points if j.enable])
+    expected_logs = ""
+
+    res = job.job_import_data(target=None)
+
+    # FIXME: Logline says 10s regardless of job.wait_job_start
+    expected_logs += "INFO     root:dependencies.py:81 DÉMARRAGE DU JOB D'IMPORTATION DANS 10S\n"
+    assert res["status"] is True
+    for method, m in mockers.items():
+        if method in PER_JOB_METHODS:
+            assert m.call_count == 1
+        else:
+            assert m.call_count == count_enabled_jobs
+        m.reset_mock()
+
+    assert expected_logs in caplog.text
+
+
+def test_header_generate(job, caplog):
+    from dependencies import get_version
+    expected_logs = ""
+    # FIXME: header_generate() assumes job.usage_point_config is populated from a side effect
+    for job.usage_point_config in job.usage_points:
+        assert {'Authorization': '', 'Content-Type': 'application/json', 'call-service': 'myelectricaldata',
+                'version': get_version()} == job.header_generate()
+    assert expected_logs == caplog.text
+
+
+@pytest.mark.parametrize("ping_side_effect", [None, Exception("Mocker: Ping failed")])
+def test_get_gateway_status(job, caplog, ping_side_effect, mocker):
+    m_ping = mocker.patch("models.query_status.Status.ping")
+    m_ping.side_effect = ping_side_effect
+    m_ping.return_value = {"mocked": "true"}
+
+    job.get_gateway_status()
+
+    if ping_side_effect:
+        assert "ERROR    root:jobs.py:169 Erreur lors de la récupération du statut de la passerelle :" in caplog.text
+    else:
+        assert "INFO     root:dependencies.py:81 RÉCUPÉRATION DU STATUT DE LA PASSERELLE :" in caplog.text
+
+
+@pytest.mark.parametrize('status_return_value, is_supported', [
+    ({}, True),
+    ({'any_key': 'any_value'}, True),
+    ({'error': 'only'}, False),
+    ({'error': 'with all fields', 'status_code': '5xx', 'description': {'detail': 'proper error'}}, True)
+])
+@pytest.mark.parametrize('status_side_effect', [None, Exception("Mocker: Status failed")])
+def test_get_account_status(mocker, job, caplog, status_side_effect, status_return_value, is_supported):
+    m_status = mocker.patch("models.query_status.Status.status")
+    m_set_error_log = mocker.patch("models.database.Database.set_error_log")
+    mocker.patch('models.jobs.Job.header_generate')
+
+    m_status.side_effect = status_side_effect
+    m_status.return_value = status_return_value
+
+    enabled_usage_points = [up for up in job.usage_points if up.enable]
+    if not job.usage_point_id:
+        expected_count = len(enabled_usage_points)
+    else:
+        expected_count = 1
+        # If job has usage_point_id, get_account_status() expects
+        # job.usage_point_config.usage_point_id to be populated from a side effect
+        job.usage_point_config = UsagePoints(usage_point_id=job.usage_point_id)
+
+    res = job.get_account_status()
+
+    assert "INFO     root:dependencies.py:81 [PDL1] RÉCUPÉRATION DES INFORMATIONS DU COMPTE :" in caplog.text
+    if status_side_effect is None and is_supported:
+        assert expected_count == m_set_error_log.call_count
+        if status_return_value.get("error"):
+            m_set_error_log.assert_called_with('pdl1', '5xx - proper error')
+    elif status_side_effect:
+        assert "ERROR    root:jobs.py:195 Erreur lors de la récupération des informations du compte" in caplog.text
+        assert f"ERROR    root:jobs.py:196 {status_side_effect}" in caplog.text
+        # set_error_log is not called in case status() raises an exception
+        assert 0 == m_set_error_log.call_count
+    elif not is_supported:
+        assert "ERROR    root:jobs.py:195 Erreur lors de la récupération des informations du compte" in caplog.text
+        assert "ERROR    root:jobs.py:196 'status_code'" in caplog.text
+        # FIXME: set_error_log is not called in case status() returns
+        # a dict with an error key but no status_code or description.detail
+        assert 0 == m_set_error_log.call_count
+
+    # Ensuring status() is called exactly as many times as enabled usage_points
+    # and only once per enabled usage_point
+    assert expected_count == m_status.call_count
+    for j in enabled_usage_points:
+        m_status.assert_called_once_with(usage_point_id=j.usage_point_id)
+
+
+@pytest.mark.parametrize('method, patch, details, line_no', [
+    ("get_contract", "models.query_contract.Contract.get", "Récupération des informations contractuelles", 217),
+    ("get_addresses", "models.query_address.Address.get", "Récupération des coordonnées postales", 238),
+    ("get_consumption", "models.query_daily.Daily.get", "Récupération de la consommation journalière", 262),
+    ("get_consumption_detail", "models.query_detail.Detail.get", "Récupération de la consommation détaillée", 286),
+    ("get_production", "models.query_daily.Daily.get", "Récupération de la production journalière", 313),
+    ("get_production_detail", "models.query_detail.Detail.get", "Récupération de la production détaillée", 337),
+    ("get_consumption_max_power", "models.query_power.Power.get", "Récupération de la puissance maximum journalière",
+     358),
+])
+@pytest.mark.parametrize('return_value', [
+    {},
+    {'any_key': 'any_value'},
+    {'error': 'only'},
+    {'error': 'with all fields', 'status_code': '5xx', 'description': {'detail': 'proper error'}}
+])
+@pytest.mark.parametrize('side_effect', [None, Exception("Mocker: call failed")])
+def test_get_no_return_check(mocker, job, caplog, side_effect, return_value, method, patch, details, line_no):
+    """
+    This test covers all methods that call "get" methods from query objects:
+    - without checking for their return value
+    - without calling set_error_log on failure
+    """
+
+    m = mocker.patch(patch)
+    m_set_error_log = mocker.patch("models.database.Database.set_error_log")
+    mocker.patch('models.jobs.Job.header_generate')
+
+    m.side_effect = side_effect
+    m.return_value = return_value
+
+    conf = job.config.usage_point_id_config(job.usage_point_id)
+    enabled_usage_points = [up for up in job.usage_points if up.enable]
+    if not job.usage_point_id:
+        expected_count = len(enabled_usage_points)
+    else:
+        expected_count = 1
+        # FIXME: If job has usage_point_id, get_account_status() expects
+        # job.usage_point_config.usage_point_id to be populated from a side effect
+        job.usage_point_config = UsagePoints(
+            usage_point_id=job.usage_point_id,
+            consumption=conf.get("consumption"),
+            consumption_detail=conf.get("consumption_detail"),
+            production=conf.get("production"),
+            production_detail=conf.get("production_detail")
+        )
+
+    res = getattr(job, method)()
+
+    if method == "get_consumption_max_power" and job.usage_point_id is None:
+        # This method uses self.usage_point_id instead of usage_point_id
+        assert f"INFO     root:dependencies.py:81 [NONE] {details.upper()} :" in caplog.text
+    else:
+        assert f"INFO     root:dependencies.py:81 [PDL1] {details.upper()} :" in caplog.text
+
+    if side_effect:
+        # When get() throws an exception, no error is displayed
+        assert f"ERROR    root:jobs.py:{line_no} Erreur lors de la {details.lower()}" in caplog.text
+        assert f"ERROR    root:jobs.py:{line_no + 1} {side_effect}" in caplog.text
+    elif return_value:
+        # No matter what get() returns, the method will never log an error
+        assert f"ERROR    root:jobs.py:{line_no} Erreur lors de la {details.lower()}" not in caplog.text
+        assert f"ERROR    root:jobs.py:{line_no + 1} 'status_code'" not in caplog.text
+
+    # Ensuring method is called exactly as many times as enabled usage_points
+    assert expected_count == m.call_count
+
+    # set_error_log is never called
+    m_set_error_log.assert_not_called()


### PR DESCRIPTION
### Motivation
Afin de me familiariser avec l'application, je me suis permis d'ecrire des tests unitaires
Cette PR couvre principalement le module `jobs.py`

### Changements
- Reutilisation de la variable `APPLICATION_PATH_DATA` quand cela semblait pertinent
- Ajout de `pytest.ini`, `tests/`
- Ajout d'une notice de tests dans `TESTING.md` contenant les indications pour creer une github action
- Ajout de tests unitaires dans `tests/`: ces tests valident le fonctionnement du module ainsi que la position exacte des lignes de logs renvoyees, ce qui peut paraitre extreme, mais je voulais eviter de perturber le logging une nouvelle fois.

### Note
Ma PR precedente avait 2 soucis:
- Les tests ne fonctionnaient pas
Les tests se basaient sur le dossier `tests/data/` que je n'avais pas commité. 
Desormais, les tests se basent sur un dossier temporaire.

- L'ajout des tests a fait disparaitre les logs
Cela etait du a l'introduction de `alembic.command` a la place de`os.system` pour effectuer les migrations.
Comme precise dans la [documentation](https://alembic.sqlalchemy.org/en/latest/api/config.html), il y a une interaction entre `alembic.command` et `env.py`:
> When using programmatic configuration, make sure the env.py file in use is compatible with the target configuration; including that the call to Python logging.fileConfig() is omitted if the programmatic configuration doesn’t actually include logging directives.

J'ai donc choisi de retirer mon usage de `alembic.command`