### PR TITLE
fix: handle inconsistent consumption/production

### DIFF
--- a/app/models/query_detail.py
+++ b/app/models/query_detail.py
@@ -151,6 +151,7 @@ class Detail:
                                 interval=interval,
                                 measure_type=measure_type,
                                 blacklist=0,
+                                mesure_type=self.measure_type
                             )
                         return meter_reading["interval_reading"]
                     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,8 @@ def mock_config(data_dir):
                 "consumption": True,
                 "consumption_detail": True,
                 "production": True,
-                "production_detail": True
+                "production_detail": True,
+                "token": "abcd",
             },
             "pdl2": {"enable": False},
             "pdl3": {"enable": False}

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -68,7 +68,7 @@ def test_header_generate(job, caplog):
     expected_logs = ""
     # FIXME: header_generate() assumes job.usage_point_config is populated from a side effect
     for job.usage_point_config in job.usage_points:
-        assert {'Authorization': '', 'Content-Type': 'application/json', 'call-service': 'myelectricaldata',
+        assert {'Authorization': job.usage_point_config.token, 'Content-Type': 'application/json', 'call-service': 'myelectricaldata',
                 'version': get_version()} == job.header_generate()
     assert expected_logs == caplog.text
 

--- a/tests/test_query_detail.py
+++ b/tests/test_query_detail.py
@@ -1,0 +1,40 @@
+import dataclasses
+import datetime
+from unittest import mock
+
+import pytest
+
+
+@dataclasses.dataclass
+class MockResponse:
+    status_code: int
+    text: str = ''
+
+
+@pytest.mark.parametrize("measure_type", ["consumption", "production"])
+def test_get(mocker, measure_type):
+    from models.query_detail import Detail
+
+    m_get: mock.Mock = mocker.patch("models.query.Query.get")
+    m_insert_detail: mock.Mock = mocker.patch("models.database.Database.insert_detail")
+    m_get.return_value = MockResponse(status_code=200,
+                                      text='{"meter_reading": {"interval_reading": [{"interval_length": "30", '
+                                           '"value": "10", "date": "2024-01-01 00:00:00"}]}}')
+
+    # Instantiating a Detail class, pointing to a valid usage_point_id
+    d = Detail(headers="any", usage_point_id="pdl1", measure_type=measure_type)
+
+    # Using a very large max_detail value so that the mock is called only once
+    d.max_detail = 3650
+
+    # Triggering Details.get(), which should
+    # - call m_get mock, which returns the value above
+    # - call m_insert_detail with parameters that are consistent with the value returned at the previous step
+    d.get()
+
+    # Query.get() should only be called once, with no parameter
+    m_get.assert_called_once_with()
+    # Database.insert_details() should only be called once, with parameters below
+    m_insert_detail.assert_called_once_with(date=datetime.datetime(2023, 12, 31, 23, 30, 00), interval='30',
+                                            measure_type='HP', mesure_type=measure_type, usage_point_id='pdl1',
+                                            value='10', blacklist=0)

--- a/tests/test_usage_point.py
+++ b/tests/test_usage_point.py
@@ -1,0 +1,91 @@
+
+
+def test_consumption_vs_production_consistent():
+    from templates.usage_point import UsagePoint
+
+    up = UsagePoint("pdl1")
+    up.recap_production_data = {"2023": {"month": {1: 2, 2: 2, 3: 2}}}
+    up.recap_consumption_data = {"2023": {"month": {1: 1, 2: 1, 3: 1}}}
+    up.consumption_vs_production("2023")
+    assert up.javascript == """            
+            google.charts.load("current", {packages:["corechart"]});
+            google.charts.setOnLoadCallback(drawChartProductionVsConsumption2023);
+            function drawChartProductionVsConsumption2023() {
+                var data = google.visualization.arrayToDataTable([
+                ['Mois', 'Consommation', 'Production'],
+            ['1', 0.001, 0.002],['2', 0.001, 0.002],['3', 0.001, 0.002],
+                ])
+                data.sort([{column: 0}]);
+                var options = {
+                  title : '2023',
+                  vAxis: {title: 'Consommation (kWh)'},
+                  hAxis: {title: 'Mois'},
+                  seriesType: 'bars',
+                  series: {5: {type: 'line'}}
+                };
+    
+                var chart = new google.visualization.ComboChart(document.getElementById('chart_daily_production_compare_2023'));
+                chart.draw(data, options);
+            }
+            """
+
+
+def test_consumption_vs_production_wrong_year():
+    from templates.usage_point import UsagePoint
+
+    up = UsagePoint("pdl1")
+    up.recap_production_data = {"2023": {"month": {1: 2, 2: 2, 3: 2}}}
+    up.recap_consumption_data = {"2022": {"month": {1: 1, 2: 1, 3: 1}}, "2023": {"month": {1: 1, 2: 1, 3: 1}}}
+    up.consumption_vs_production("2022")
+    assert up.javascript == """            
+            google.charts.load("current", {packages:["corechart"]});
+            google.charts.setOnLoadCallback(drawChartProductionVsConsumption2022);
+            function drawChartProductionVsConsumption2022() {
+                var data = google.visualization.arrayToDataTable([
+                ['Mois', 'Consommation', 'Production'],
+            ['1', 0.001, 0.0],['2', 0.001, 0.0],['3', 0.001, 0.0],
+                ])
+                data.sort([{column: 0}]);
+                var options = {
+                  title : '2022',
+                  vAxis: {title: 'Consommation (kWh)'},
+                  hAxis: {title: 'Mois'},
+                  seriesType: 'bars',
+                  series: {5: {type: 'line'}}
+                };
+    
+                var chart = new google.visualization.ComboChart(document.getElementById('chart_daily_production_compare_2022'));
+                chart.draw(data, options);
+            }
+            """
+
+
+def test_consumption_vs_production_inconsistent():
+    from templates.usage_point import UsagePoint
+
+    up = UsagePoint("pdl1")
+    up.recap_production_data = {"2023": {"month": {1: 2, 3: 2}}}
+    up.recap_consumption_data = {"2023": {"month": {2: 1, 4: 1}}}
+    up.consumption_vs_production("2023")
+    assert up.javascript == """            
+            google.charts.load("current", {packages:["corechart"]});
+            google.charts.setOnLoadCallback(drawChartProductionVsConsumption2023);
+            function drawChartProductionVsConsumption2023() {
+                var data = google.visualization.arrayToDataTable([
+                ['Mois', 'Consommation', 'Production'],
+            ['1', 0.0, 0.002],['2', 0.001, 0.0],['3', 0.0, 0.002],['4', 0.001, 0.0],
+                ])
+                data.sort([{column: 0}]);
+                var options = {
+                  title : '2023',
+                  vAxis: {title: 'Consommation (kWh)'},
+                  hAxis: {title: 'Mois'},
+                  seriesType: 'bars',
+                  series: {5: {type: 'line'}}
+                };
+    
+                var chart = new google.visualization.ComboChart(document.getElementById('chart_daily_production_compare_2023'));
+                chart.draw(data, options);
+            }
+            """
+


### PR DESCRIPTION
## Motivation
Lors que `usage_point.consumption_vs_production(year)` est appele avec une annee qui contient uniquement de la production, ou uniquement de la consommation, l'application crashe car elle essaie d'acceder a `self.recap_production_data[year]` (cf. https://github.com/MyElectricalData/myelectricaldata_import/issues/443)

## Changements
- Modification de `usage_point.consumption_vs_production(year)` afin que la methode supporte les cas suivants:
  * Cas nominal: Production et Consommation pendant les memes mois
  * Cas d'absence d'une annee: Consommation en 2022, mais Production inexistante en 2022
  * Cas d'incoherence entre les mois: En Janvier, seulement de la consommation; En Fevrier, seulement de la production
- Ajout du parametre `mesure_type` lors de l'appel a `Database.insert_details()` afin de declencher l'ecriture dans la bonne table (ie. ProductionDetail ou ConsumptionDetail)
- Ajout des tests correspondants
- Fix typo: `compare_compsuption_production` -> `compare_comsuption_production`

## Note
Cette PR se base sur la configuration de tests introduite dans https://github.com/MyElectricalData/myelectricaldata_import/pull/455. C'est pourquoi elle embarque les commits concernes.