### PR TITLE
feat: connect to mqtt via ssl using certificate authority (ie. no host validation)

### DIFF
--- a/app/init.py
+++ b/app/init.py
@@ -120,5 +120,6 @@ if MQTT_CONFIG and "enable" in MQTT_CONFIG and str2bool(MQTT_CONFIG["enable"]):
         client_id=MQTT_CONFIG["client_id"],
         prefix=MQTT_CONFIG["prefix"],
         retain=MQTT_CONFIG["retain"],
-        qos=MQTT_CONFIG["qos"]
+        qos=MQTT_CONFIG["qos"],
+        ca_cert=MQTT_CONFIG.get("ca_cert"),
     )

--- a/app/models/mqtt.py
+++ b/app/models/mqtt.py
@@ -16,7 +16,8 @@ class Mqtt:
             prefix="myelectricaldata",
             retain=True,
             qos=0,
-            port=1883
+            port=1883,
+            ca_cert=None
     ):
         self.hostname = hostname
         self.port = port
@@ -28,6 +29,7 @@ class Mqtt:
         self.qos = qos
 
         self.client = {}
+        self.ca_cert = ca_cert
         self.connect()
 
     def connect(self):
@@ -37,6 +39,9 @@ class Mqtt:
             self.client = mqtt.Client(self.client_id)
             if self.username != "" and self.password != "":
                 self.client.username_pw_set(self.username, self.password)
+            if self.ca_cert:
+                logging.info(f"Using ca_cert: {self.ca_cert}")
+                self.client.tls_set(ca_certs=self.ca_cert)
             self.client.connect(self.hostname, self.port)
             self.client.loop_start()
             title("Connection success")

--- a/config.exemple.yaml
+++ b/config.exemple.yaml
@@ -52,6 +52,7 @@ mqtt:
   client_id: myelectricaldata     # DOIT ETRE UNIQUE SUR LA TOTALITE DES CLIENTS CONNECTE AU SERVEUR MQTT
   retain: true
   qos: 0
+#  ca_cert: /certs/ca.pem         # Certificate Authority a utiliser pour etablir une connection SSL au server MQTT
 # Configuration SSL optionnel.
 #ssl:
 #  keyfile: "/data/key.pem"


### PR DESCRIPTION
## Motivation
https://github.com/MyElectricalData/myelectricaldata_import/issues/454

## Changements
Ajout d'un parametre de configuration dans la section `mqtt` pour pointer vers le CA a utiliser
Note: Le traffic sera uniquement chiffre, cette fonctionnalite ne permet pas d'authentifier le client.