### PR TITLE
Replacing 'year'-number with 'current' in case it is current year

### DIFF
--- a/src/models/export_mqtt.py
+++ b/src/models/export_mqtt.py
@@ -104,7 +104,10 @@ class ExportMqtt:
                 get_daily_year = stat.get_year(year=year)
                 get_daily_month = stat.get_month(year=year)
                 get_daily_week = stat.get_week(year=year)
-                sub_prefix = f"{self.usage_point_id}/{measurement_direction}/annual/{year}"
+                if year == int(datetime.now().strftime("%Y")):
+                    sub_prefix = f"{self.usage_point_id}/{measurement_direction}/annual/current"
+                else:
+                    sub_prefix = f"{self.usage_point_id}/{measurement_direction}/annual/{year}"
                 mqtt_data = {
                     # thisYear
                     f"{sub_prefix}/thisYear/dateBegin": get_daily_year["begin"],
@@ -247,7 +250,10 @@ class ExportMqtt:
                     measure_type="HC",
                 )
 
-                sub_prefix = f"{self.usage_point_id}/{measurement_direction}/annual/{year}"
+                if year == int(datetime.now().strftime("%Y")):
+                    sub_prefix = f"{self.usage_point_id}/{measurement_direction}/annual/current" 
+                else:
+                    sub_prefix = f"{self.usage_point_id}/{measurement_direction}/annual/{year}"
                 mqtt_data = {
                     # thisYear - HP
                     f"{sub_prefix}/thisYear/hp/Wh": get_detail_year_hp["value"],
@@ -460,6 +466,8 @@ class ExportMqtt:
             mqtt_data[f"tempo/color/tomorrow"] = tempo_color[0].color
         if tempo_data:
             for year, data in ast.literal_eval(tempo_data[0].value).items():
+                if year == datetime.now().strftime("%Y"):
+                    year = "current"
                 for color, tempo in data["TEMPO"].items():
                     mqtt_data[f"{self.usage_point_id}/consumption/annual/{year}/thisYear/tempo/{color}/Wh"] = round(
                         tempo["Wh"], 2

--- a/src/models/export_mqttv1.py
+++ b/src/models/export_mqttv1.py
@@ -227,9 +227,10 @@ class ExportMqtt:
             date_begin_current = datetime.combine(date_end.replace(month=1).replace(day=1), datetime.min.time())
             finish = False
             while not finish:
-                sub_prefix = (
-                    f"{self.usage_point_id}/{self.measurement_direction}/annual/{date_begin_current.strftime('%Y')}"
-                )
+                if date_begin_current.strftime('%Y') == datetime.now().strftime("%Y"):
+                    sub_prefix = f"{self.usage_point_id}/{self.measurement_direction}/annual/current"
+                else: 
+                    sub_prefix = f"{self.usage_point_id}/{self.measurement_direction}/annual/{date_begin_current.strftime('%Y')}"
                 self.load_daily_data(date_begin_current, date_end, price, sub_prefix)
                 # CALCUL NEW DATE
                 if date_begin_current == date_begin:
@@ -391,9 +392,10 @@ class ExportMqtt:
             date_begin_current = datetime.combine(date_end.replace(month=1).replace(day=1), datetime.min.time())
             finish = False
             while not finish:
-                sub_prefix = (
-                    f"{self.usage_point_id}/{self.measurement_direction}/annual/{date_begin_current.strftime('%Y')}"
-                )
+                if date_begin_current.strftime('%Y') == datetime.now().strftime("%Y"):
+                    sub_prefix = f"{self.usage_point_id}/{self.measurement_direction}/annual/current"
+                else:
+                    sub_prefix = f"{self.usage_point_id}/{self.measurement_direction}/annual/{date_begin_current.strftime('%Y')}"
                 self.load_detail_data(date_begin_current, date_end, price_hp, price_hc, sub_prefix)
                 # CALCUL NEW DATE
                 if date_begin_current == date_begin:


### PR DESCRIPTION
Allows to call MQTT topics having data for current tear directly from HA sensor (and others)
Example below, 2024 is replaced by 'current'

![image](https://github.com/MyElectricalData/myelectricaldata_import/assets/44190435/00e152d4-f58e-40f9-ada8-7c9c77dc8650)
