### PR TITLE
fix export to influxdb for production

### DIFF
--- a/src/models/export_influxdb.py
+++ b/src/models/export_influxdb.py
@@ -129,6 +129,7 @@ class ExportInfluxDB:
                         else:
                             euro = kwatth * self.usage_point_config.consumption_price_hc
                     else:
+                        measure_type = "BASE"
                         euro = kwatth * self.usage_point_config.production_price
                     INFLUXDB.write(
                         measurement=measurement,


### PR DESCRIPTION
Hello,

Lorsque j'importe des données de production vers InfluxDB, j'obtenais une erreur, car le `measure_type` n'étais pas défini.

Dans le cas de production, je lui ai attribué une valeur par défaut pour faire simple. Je connais assez mal le métier, mais s'il y a mieux à faire, n'hésitez pas à me le dire, j'adapterai au mieux.

J'ai mis BASE en valeur par défaut, car je ne l'utilise pas sur mon tableau de bord. J'ai l'impression que c'est d'ailleurs un tag qui est inutile dans le cadre de la production.

Merci,
Fred